### PR TITLE
Adiciona version no docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-
+version: "3"
 services:
 
   admin-api:


### PR DESCRIPTION
Na versão:
 ```
$ docker-compose --version                                
docker-compose version 1.25.5, build 8a1c60f6
```
O comando 
```
$ docker-compose up
ERROR: The Compose file './docker-compose.yml' is invalid because:                                                                                                                                                   
Unsupported config option for services: 'admin-api'
```
Reclama que o aquivo `docker-compose.yml` é invalido.

Para corrigir o problema é adicionar um version do arquivo `docker-compose.yml`.